### PR TITLE
Basic Python 3 compatibility

### DIFF
--- a/.bzrignore
+++ b/.bzrignore
@@ -1,6 +1,0 @@
-.installed.cfg
-*.egg-info
-bin
-develop-eggs
-eggs
-parts

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Change Log
 1.6 (unreleased)
 ----------------
 
-- TBD
+- Added basic Python 3 compatibility.  Not complete yet:
+  it may need changes in GenericSetup.
+
 
 1.5 (2017-05-04)
 ----------------

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 recursive-include Products *
-include *
+include *txt *rst
 global-exclude *.pyc

--- a/Products/PluginRegistry/exportimport.py
+++ b/Products/PluginRegistry/exportimport.py
@@ -16,10 +16,9 @@
 
 $Id$
 """
-from StringIO import StringIO
 
 from Persistence import PersistentMapping
-from zope.interface import implements
+from zope.interface import implementer
 
 from Products.GenericSetup.interfaces import IFilesystemExporter
 from Products.GenericSetup.interfaces import IFilesystemImporter
@@ -33,8 +32,10 @@ from Products.GenericSetup.utils import CONVERTER
 from Products.GenericSetup.utils import DEFAULT
 from Products.GenericSetup.utils import KEY
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
+from six import StringIO
 
-from interfaces import IPluginRegistry
+from Products.PluginRegistry.interfaces import IPluginRegistry
+
 
 def _providedBy(obj, iface):
     return iface.providedBy(obj)
@@ -46,10 +47,10 @@ def _getRegistry(site):
                     if _providedBy(x, IPluginRegistry)]
 
     if len(registries) < 1:
-        raise ValueError, 'No plugin registries'
+        raise ValueError('No plugin registries')
 
     if len(registries) > 1:
-        raise ValueError, 'Too many plugin registries'
+        raise ValueError('Too many plugin registries')
 
     return registries[0]
 
@@ -150,10 +151,11 @@ class PluginRegistryImporter(ImportConfiguratorBase):
             },
          }
 
+
+@implementer(IFilesystemExporter, IFilesystemImporter)
 class PluginRegistryFileExportImportAdapter(object):
     """ Designed for ues when exporting / importing PR's within a container.
     """
-    implements(IFilesystemExporter, IFilesystemImporter)
 
     def __init__(self, context):
         self.context = context

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    https://zopefoundation.github.io/Zope/releases/4.0a5/versions-prod.cfg
+    http://zopefoundation.github.io/Zope/releases/4.0b2/versions-prod.cfg
 parts =
     zopepy
     test

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[check-manifest]
+ignore =
+    *.cfg
+    bootstrap.py
+    tox.ini
+
+[bdist_wheel]
+universal = 1
+
+[zest.releaser]
+create-wheel = yes

--- a/setup.py
+++ b/setup.py
@@ -28,13 +28,12 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Plone",
-        "Framework :: Plone :: 4.3",
-        "Framework :: Plone :: 5.0",
-        "Framework :: Plone :: 5.1",
+        "Framework :: Plone :: 5.2",
         "Framework :: Zope2",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Zope Public License",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Topic :: Software Development",
         "Topic :: System :: Archiving :: Packaging",
@@ -51,6 +50,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'setuptools',
+        'six',
         'Zope2 >= 4.0a3',
         'Products.GenericSetup >= 1.9.0'
         ],


### PR DESCRIPTION
Issue #3. Needs changes in GenericSetup to really work. But at least there are no SyntaxErrors on Python 3, and on Python 2.7 the tests pass.