### PR TITLE
Use correct version configuration

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,6 +1,7 @@
 [buildout]
 extends =
-    http://zopefoundation.github.io/Zope/releases/4.x/versions-prod.cfg
+    https://zopefoundation.github.io/Zope/releases/4.x/versions-prod.cfg
+    https://zopefoundation.github.io/Zope/releases/4.x/versions.cfg
 parts =
     zopepy
     test


### PR DESCRIPTION
ie use pinned versions of Zope 4, which still supports Python 2.7.
modified:   buildout.cfg